### PR TITLE
Disable download artifact button until page reload

### DIFF
--- a/src/app/pages/market/product.twig
+++ b/src/app/pages/market/product.twig
@@ -37,11 +37,17 @@
   .product-download .button.special.install, 
   .product-header .button.special.install {
     background-color: #C7D426;
+    min-width: 150px;
   }
   .product-install .button.special.download,
   .product-download .button.special.download, 
   .product-header .button.special.download {
     background-color: white;
+  }
+  .product-install .button.special.install .si,
+  .product-download .button.special.install .si, 
+  .product-header .button.special.install .si {
+    background-color: #1b1b1b;
   }
   .product-download,
   .product-install,
@@ -155,7 +161,7 @@
       {% if mavenProductInfo != null %}
        <span class="dropdown">
           <label>Choose target platform</label>
-          <select name="version" id="version" onchange="location = this.value + '#download';">
+          <select name="version" id="version" onchange="updateDownloadArtifact(this);">
           {% for version in mavenProductInfo.versionsToDisplay %}            
             <a href="#">
               <option value="{{ product.url }}/{{ version }}" {{ (version == selectedVersion) ? 'selected' : '' }}>Version {{ version|replace({'-SNAPSHOT':''}) }}</option>
@@ -166,7 +172,7 @@
       {% endif %}
 
       <a class="button special install artifact" href="javascript:void(0)" onclick="downloadArtifact()">
-        <span>Download</span>
+        <span class="download-artifact-btn">Download</span>
       </a>
     </article>
   </div>
@@ -197,8 +203,15 @@
 
 
 <script>
+  function updateDownloadArtifact(selection) { 
+    $('.download-artifact-btn').parent().addClass('disabled');
+    $('.download-artifact-btn').text('').addClass('si si-refresh si-is-spinning');
+    location = selection.value + '#download';
+  }
   function downloadArtifact() {
-    window.location = $('#artifact').val();
+    if (!$('.download-artifact-btn').parent().hasClass('disabled')) {
+      window.location = $('#artifact').val();
+    }
   }
   function toggleDownloadPanel() {
     $('.product-download').slideToggle();

--- a/src/web/assets/css/icons.css
+++ b/src/web/assets/css/icons.css
@@ -24,6 +24,44 @@ h3 .si {
   margin: 0 10px;
 }
 
+.si.si-is-spinning {
+  -webkit-animation: icon-spin 2s infinite linear reverse;
+  -moz-animation: icon-spin 2s infinite linear reverse;
+  animation: icon-spin 2s infinite linear reverse;
+}
+@-webkit-keyframes icon-spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
+  }
+}
+@-moz-keyframes icon-spin {
+  0% {
+    -moz-transform: rotate(0deg);
+  }
+  100% {
+    -moz-transform: rotate(360deg);
+  }
+}
+@keyframes icon-spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    -o-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    -o-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
   .si {
     width: 0 !important;


### PR DESCRIPTION
Disable download artifact button on market product page if you change the version and the page reloads.
- Add spinning refresh icon while loading