### PR TITLE
XIVY-6324 Generate RCPTT test case based on current products on demand

### DIFF
--- a/src/app/RoutingRules.php
+++ b/src/app/RoutingRules.php
@@ -33,6 +33,7 @@ use app\permalink\LinkAction;
 use app\pages\market\MetaJsonAction;
 use app\pages\market\OpenApiJsonAction;
 use app\pages\market\MetaRedirectAction;
+use app\pages\internal\MarketRCPTTAction;
 
 class RoutingRules
 {
@@ -75,6 +76,7 @@ class RoutingRules
     $app->get('/market/{key}[/{version}]', ProductAction::class);
     $app->get('/_market/{key}/_meta.json', MetaJsonAction::class);
     $app->get('/_market/{key}/openapi', OpenApiJsonAction::class);
+    $app->get('/internal/market-rcptt', MarketRCPTTAction::class);
 
     $app->get('/portal[/{version}[/{topic}[/{path:.*}]]]', PortalPermalinkAction::class);
 

--- a/src/app/pages/internal/MarketRCPTTAction.php
+++ b/src/app/pages/internal/MarketRCPTTAction.php
@@ -1,0 +1,57 @@
+<?php
+namespace app\pages\internal;
+
+use Slim\Views\Twig;
+use app\domain\market\Market;
+use app\domain\market\Product;
+use Slim\Psr7\Request;
+use Slim\Psr7\Response;
+use Slim\Exception\HttpNotFoundException;
+
+class MarketRCPTTAction
+{
+
+  private Twig $view;
+
+  public function __construct(Twig $view)
+  {
+    $this->view = $view;
+  }
+
+  public function __invoke(Request $request, Response $response, $args)
+  {
+    $queryParams = $request->getQueryParams();
+    $designerVersion = $queryParams['designerVersion'] ?? null;
+
+    if ($designerVersion == null) {
+        throw new HttpNotFoundException($request);
+    }
+
+    $products = self::products();
+    $baseUrl = self::baseUrl();
+
+    $urls = [];
+    foreach ($products as $product) {
+        $mavenInfo = $product->getMavenProductInfo();
+        $bestMatchingVersion = $mavenInfo->findBestMatchingVersion($designerVersion);
+        $urls[] = $baseUrl . $product->getMetaUrl($bestMatchingVersion);
+    }
+
+    $response = $response->withHeader('Content-Type', 'text/plain');
+    return $this->view->render($response, 'internal/market-rcptt.twig', [
+      'urls' => $urls
+    ]);
+  }
+
+  private static function products(): array {
+    $products = Market::listed();
+    $products = array_filter($products, fn (Product $product) => $product->getMavenProductInfo() != null);
+    $products = array_filter($products, fn (Product $product) => $product->isInstallable());
+    return $products;
+  }
+
+  private static function baseUrl(): string {
+    $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
+    return (isset($_SERVER['HTTPS']) ? "https" : "http") . "://$host";
+  }
+}

--- a/src/app/pages/internal/market-rcptt.twig
+++ b/src/app/pages/internal/market-rcptt.twig
@@ -1,0 +1,3 @@
+{% for url in urls %}
+  runTest {{ url }}
+{% endfor %}

--- a/test/pages/internal/MarketRCPTTTest.php
+++ b/test/pages/internal/MarketRCPTTTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace test\pages\github;
+
+use PHPUnit\Framework\TestCase;
+use test\AppTester;
+
+class MarketRCPTTTest extends TestCase
+{
+  public function testRender()
+  {
+    AppTester::assertThatGet('/internal/market-rcptt?designerVersion=9.2.0')
+      ->ok()
+      ->bodyContains('runTest https://fakehost/_market/portal/_meta.json?version=9.2.0');
+  }
+
+  public function notFound()
+  {
+    AppTester::assertThatGet('/internal/market-rcptt')->notFound();
+  }
+}


### PR DESCRIPTION
To import and validate projects within RCPTT in Axon Ivy Designer. I create the test case of RCPTT on the fly and highly generic for all potential market artifacts.

I can now call this website with a given designer version. There is already logic about which product version best matches the given designer version. Let's use this again in our test suite so we never have to maintain anywhere any version numbers.

`http://localhost/internal/market-rcptt?designerVersion=9.2.0`
Will give a list of all listed products, which are backed by Maven and can be installed.

![grafik](https://user-images.githubusercontent.com/7498380/137489650-d9b036da-03aa-48dc-b9d2-184ae34fd3d3.png)
