### PR TITLE
XIVY-6828 Enrich product.json with name for Axon Ivy Designer

### DIFF
--- a/src/app/pages/market/MetaJsonAction.php
+++ b/src/app/pages/market/MetaJsonAction.php
@@ -24,6 +24,10 @@ class MetaJsonAction
     $content = $product->getMetaJson();
     $content = str_replace('${version}', $version, $content);
 
+    $json = json_decode($content);
+    $json->name = $product->getName();
+    $content = json_encode($json);
+
     $response->getBody()->write($content);
     $response = $response->withHeader('Content-Type', 'application/json');
     return $response;

--- a/src/app/pages/market/ProductJsonAction.php
+++ b/src/app/pages/market/ProductJsonAction.php
@@ -25,6 +25,10 @@ class ProductJsonAction
     MarketInstallCounter::incrementInstallCount($key);
     $content = $product->getProductJson($version);
     $content = str_replace('${version}', $version, $content);
+    
+    $json = json_decode($content);
+    $json->name = $product->getName();
+    $content = json_encode($json);
 
     $response->getBody()->write($content);
     $response = $response->withHeader('Content-Type', 'application/json');

--- a/test/pages/market/MetaJsonActionTest.php
+++ b/test/pages/market/MetaJsonActionTest.php
@@ -13,7 +13,7 @@ class MetaJsonActionTest extends TestCase
     AppTester::assertThatGet('/_market/doc-factory/_product.json?version=8.0.1')
       ->ok()
       ->header('Content-Type', 'application/json')
-      ->bodyContains('"version": "8.0.1"');
+      ->bodyContains('"version":"8.0.1"');
   }
 
   public function testServeMetaJsonMissingVersion()
@@ -21,7 +21,7 @@ class MetaJsonActionTest extends TestCase
     AppTester::assertThatGet('/_market/doc-factory/_product.json')
       ->ok()
       ->header('Content-Type', 'application/json')
-      ->bodyContains('"version": "version-get-param-missing"');
+      ->bodyContains('"version":"version-get-param-missing"');
   }
   
   public function testServeMetaJson_stableForDesigner()


### PR DESCRIPTION
Hello @ivy-rew 

This is the only thing which needs the Axon.ivy Designer out of the meta.json
It needs the name which is not present in product.json

This is no problem as long as we serve it from the homepage. But installing the product.json in Axon Ivy Designer with CTRL+ALT+I will make an error if you create a new rest client.