### PR TITLE
Fix openapi browse link for cached artifacts

### DIFF
--- a/src/app/Config.php
+++ b/src/app/Config.php
@@ -31,7 +31,7 @@ class Config
   
   public static function marketCacheDirectory(): string
   {
-      return self::isProductionEnvironment() ? '/home/axonivya/data/market-cache' : __DIR__ . '/../../src/web/market-cache';
+    return self::isProductionEnvironment() ? '/home/axonivya/data/market-cache' : __DIR__ . '/../../src/web/market-cache';
   }
   
   public static function marketInstallationsFile(): string

--- a/src/app/domain/market/Product.php
+++ b/src/app/domain/market/Product.php
@@ -320,7 +320,7 @@ class ProductFileResolver
       return false;
     }
     $versionizedFile = $this->folder_versionized($version) . "/$file";
-    return file_exists($versionizedFile);
+    return !empty(glob($versionizedFile));
   }
   
   public function assetBaseUrl_unversionized(): string


### PR DESCRIPTION
existsFile_versionized will be called by the OpenAPIProvider with openapi.*.
If not the function checks if this file exists, this will always return false for the market-cache.
With glob this works as glob can handle wildcard, but returns an array of all found files.
So if the array is not empty a file is found.