### PR TITLE
Support market cookies over query params

### DIFF
--- a/src/app/ViewerMiddleware.php
+++ b/src/app/ViewerMiddleware.php
@@ -2,6 +2,7 @@
 
 namespace app;
 
+use app\domain\util\CookieUtil;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -21,7 +22,8 @@ class ViewerMiddleware implements MiddlewareInterface
   public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
   {
     $cookies = $request->getCookieParams();
-    $viewer = $cookies['ivy-viewer'] ?? '';
+    CookieUtil::setCookieOfQueryParam($request, 'ivy-version');
+    $viewer = $cookies['ivy-viewer'] ?? CookieUtil::setCookieOfQueryParam($request, 'ivy-viewer');
     if ($viewer == 'designer-market') {
       $env = $this->view->getEnvironment();
       $env->addGlobal('hideHeader', true);

--- a/src/app/domain/util/CookieUtil.php
+++ b/src/app/domain/util/CookieUtil.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace app\domain\util;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+class CookieUtil
+{
+  public static function setCookieOfQueryParam(ServerRequestInterface $request, string $name): string {
+    $viewer = $request->getQueryParams()[$name] ?? '';
+    if (!empty($viewer)) {
+      setcookie($name, $viewer);
+    }
+    return $viewer;
+  }
+}

--- a/src/app/pages/market/ProductAction.php
+++ b/src/app/pages/market/ProductAction.php
@@ -4,6 +4,7 @@ namespace app\pages\market;
 
 use Slim\Exception\HttpNotFoundException;
 use Slim\Views\Twig;
+use app\domain\util\CookieUtil;
 use app\domain\market\Market;
 use app\domain\market\Product;
 use Slim\Psr7\Request;
@@ -115,7 +116,7 @@ class ProductAction
   private static function readIvyVersionCookie(Request $request)
   {
     $cookies = $request->getCookieParams();
-    return $cookies['ivy-version'] ?? '';
+    return $cookies['ivy-version'] ?? CookieUtil::setCookieOfQueryParam($request, 'ivy-version');
   }
   
   private static function findBestMatchingVersionFromCookie(Request $request, MavenProductInfo $mavenProductInfo)


### PR DESCRIPTION
With this it is possible to set market cookies over get query parameters.
This is needed, if we change the market view browser to SWT.EDGE (webview2), because up to now the SWT.EDGE integration does not support to set cookies.