### PR TITLE
Improve Versions in Axon Ivy Market

### DIFF
--- a/src/app/api/StatusApi.php
+++ b/src/app/api/StatusApi.php
@@ -71,7 +71,7 @@ class StatusApi
         $latestVersionToDisplay = 'unavailable';
         $latestVersionAvailable = 'unavailable';
         try {
-          $latestVersionToDisplay = $mavenProductInfo->getLatestVersionToDisplay();
+          $latestVersionToDisplay = $mavenProductInfo->getLatestVersionToDisplay(false, null);
           $latestVersionAvailable = $mavenProductInfo->getLatestVersion();
         } catch (\Exception $ex) { }
         $p['latest-version-to-display'] = $latestVersionToDisplay;

--- a/src/app/domain/market/InstallMatcherFactory.php
+++ b/src/app/domain/market/InstallMatcherFactory.php
@@ -25,7 +25,7 @@ class BestMatchFirstInstallMatcher implements InstallMatcher
 {
   public function match(MavenProductInfo $info, string $version): string
   {
-    $versions = $info->getVersionsToDisplay();
+    $versions = $info->getVersionsToDisplay(true, null);
     foreach ($versions as $v) {
       $bugfixVersion = (new Version($v))->getBugfixVersion();
       if (version_compare($bugfixVersion, $version) <= 0) {
@@ -47,7 +47,7 @@ class LtsTrainInstallMatcher implements InstallMatcher
   public function match(MavenProductInfo $info, string $version): string
   {
     $minorVersion = (new Version($version))->getMinorVersion();
-    $versions = $info->getVersionsToDisplay();
+    $versions = $info->getVersionsToDisplay(true, null);
     foreach ($versions as $v) {
       $minorV = (new Version($v))->getMinorVersion();      
       if (version_compare($minorV, $minorVersion) <= 0) {

--- a/src/app/domain/market/MavenProductInfo.php
+++ b/src/app/domain/market/MavenProductInfo.php
@@ -101,9 +101,9 @@ class MavenProductInfo
     return $versions[count($versions) - 1];
   }
 
-  public function getLatestVersionToDisplay(): ?string
+  public function getLatestVersionToDisplay(bool $showDevVersion, ?String $requestedVersion): ?string
   {
-    $versions = $this->getVersionsToDisplay(false, null);
+    $versions = $this->getVersionsToDisplay($showDevVersion, $requestedVersion);
     if (empty($versions)) {
       return null;
     }

--- a/src/app/domain/market/MavenProductInfo.php
+++ b/src/app/domain/market/MavenProductInfo.php
@@ -68,9 +68,19 @@ class MavenProductInfo
     return $versions;
   }
 
-  public function getVersionsToDisplay(): array
+  public function getVersionsToDisplay(bool $showDevVersions, ?String $requestVersion): array
   {
-    return $this->versionDisplayFilter->versionsToDisplay($this);
+    $versions = $this->versionDisplayFilter->versionsToDisplay($this);
+    if (!$showDevVersions) {
+      if (empty($requestVersion)) {
+        $versions = array_filter($versions, fn(string $v) => !str_contains($v, '-SNAPSHOT'));
+      } else {
+        $versions = array_filter($versions, fn(string $v) => str_starts_with($v, $requestVersion) || !str_contains($v, '-SNAPSHOT'));  
+      }
+
+      $versions = array_values($versions);
+    }
+    return $versions;
   }
 
   public function getLatestVersion(): ?string
@@ -93,7 +103,7 @@ class MavenProductInfo
 
   public function getLatestVersionToDisplay(): ?string
   {
-    $versions = $this->getVersionsToDisplay();
+    $versions = $this->getVersionsToDisplay(false, null);
     if (empty($versions)) {
       return null;
     }

--- a/src/app/domain/market/Product.php
+++ b/src/app/domain/market/Product.php
@@ -94,7 +94,6 @@ class Product
     if (empty($this->version)) {
       if ($this->mavenProductInfo != null) {
         $this->version = $this->mavenProductInfo->getLatestVersion() ?? '';
-        $this->version = str_replace('-SNAPSHOT', '', $this->version);
       }
     }
     return $this->version;

--- a/src/app/pages/market/ProductAction.php
+++ b/src/app/pages/market/ProductAction.php
@@ -47,7 +47,7 @@ class ProductAction
     if (isset($request->getQueryParams()['showDevVersions'])) {
       if ($request->getQueryParams()['showDevVersions'] == "true") {
         $showDevVersions = true;
-        setcookie('showDevVersions', "true", time()+60*60*24*30 , "/");
+        setcookie('showDevVersions', "true", time()+60*60*24*30*12, "/");
       } else {
         $showDevVersions = false;
         setcookie('showDevVersions', "false", -1, "/");

--- a/src/app/pages/market/ProductAction.php
+++ b/src/app/pages/market/ProductAction.php
@@ -4,6 +4,7 @@ namespace app\pages\market;
 
 use Slim\Exception\HttpNotFoundException;
 use Slim\Views\Twig;
+use Slim\App;
 use app\domain\util\CookieUtil;
 use app\domain\market\Market;
 use app\domain\market\Product;
@@ -35,9 +36,28 @@ class ProductAction
     $installNow = isset($request->getQueryParams()['installNow']);
     $mavenProductInfo = $product->getMavenProductInfo();
     $version = $args['version'] ?? '';
+    $initVersion = $args['version'] ?? '';
     $mavenArtifactsAsDependency = [];
     $mavenArtifacts = [];
     $docUrl = '';
+    $versionsToDisplay = null;
+
+    $showDevVersionCookie = $request->getCookieParams()['showDevVersions'] ?? 'false';
+    $showDevVersions = filter_var($showDevVersionCookie, FILTER_VALIDATE_BOOLEAN) ?? false;
+    if (isset($request->getQueryParams()['showDevVersions'])) {
+      if ($request->getQueryParams()['showDevVersions'] == "true") {
+        $showDevVersions = true;
+        setcookie('showDevVersions', "true", time()+60*60*24*30 , "/");
+      } else {
+        $showDevVersions = false;
+        setcookie('showDevVersions', "false", -1, "/");
+      }
+    }
+
+    $showDevVersionsLink = "/market/$key?showDevVersions=true#download";
+    if ($showDevVersions) {
+      $showDevVersionsLink = "/market/$key?showDevVersions=false#download";
+    }
 
     if ($mavenProductInfo == null && !empty($version)) {
       throw new HttpNotFoundException($request);
@@ -52,23 +72,33 @@ class ProductAction
       } else if (!$mavenProductInfo->hasVersion($version)) {
         throw new HttpNotFoundException($request);
       }
-
-      $mavenArtifacts = $mavenProductInfo->getMavenArtifactsForVersion($version);
-      foreach ($mavenArtifacts as $artifact) {
-        if ($artifact->getMakesSenseAsMavenDependency()) {
-          $mavenArtifactsAsDependency[] = $artifact;
+      if (empty($version)) {
+        $version = '';
+      }
+      if (!empty($version)) {
+        $mavenArtifacts = $mavenProductInfo->getMavenArtifactsForVersion($version);
+        foreach ($mavenArtifacts as $artifact) {
+          if ($artifact->getMakesSenseAsMavenDependency()) {
+            $mavenArtifactsAsDependency[] = $artifact;
+          }
+        }
+        
+        
+        $mavenArtifacts = array_filter($mavenArtifacts, fn(MavenArtifact $a) => !$a->isProductArtifact());
+        $requestVersion = self::readIvyVersionCookie($request);
+        $versionsToDisplay = $mavenProductInfo->getVersionsToDisplay($showDevVersions, $requestVersion);
+        if (empty($initVersion) && !empty($versionsToDisplay)) {
+          $version = $versionsToDisplay[0];
+        }
+        
+        $docArtifact = $mavenProductInfo->getFirstDocArtifact();
+        if ($docArtifact != null) {
+          $exists = (new ProductMavenArtifactDownloader())->downloadArtifact($product, $docArtifact, $version);
+          if ($exists) {
+            $docUrl = $docArtifact->getDocUrl($product, $version);
+          }
         }
       }
-      
-      $docArtifact = $mavenProductInfo->getFirstDocArtifact();
-      if ($docArtifact != null) {
-        $exists = (new ProductMavenArtifactDownloader())->downloadArtifact($product, $docArtifact, $version);
-        if ($exists) {
-          $docUrl = $docArtifact->getDocUrl($product, $version);
-        }
-      }
-
-      $mavenArtifacts = array_filter($mavenArtifacts, fn(MavenArtifact $a) => !$a->isProductArtifact());
     }
 
     $installButton = self::createInstallButton($request, $product, $version);
@@ -100,7 +130,10 @@ class ProductAction
       'openApiUrl' => $openApiUrl,
       'version' => $productVersion,
       'docUrl' => $docUrl,
-      'installNow' => $installNow
+      'installNow' => $installNow,
+      'versionsToDisplay' => $versionsToDisplay,
+      'switchVersion' => $showDevVersions ? "hide dev versions" : "show dev versions",
+      'showDevVersionsLink' => $showDevVersionsLink
     ]);
   }
 

--- a/src/app/pages/market/ProductAction.php
+++ b/src/app/pages/market/ProductAction.php
@@ -64,10 +64,11 @@ class ProductAction
     }
 
     if ($mavenProductInfo != null) {
+      $requestVersion = self::readIvyVersionCookie($request);
       if (empty($version)) {
         $version = self::findBestMatchingVersionFromCookie($request, $mavenProductInfo);
         if (empty($version)) {
-          $version = $mavenProductInfo->getLatestVersionToDisplay();
+          $version = $mavenProductInfo->getLatestVersionToDisplay($showDevVersions, $requestVersion);
         }
       } else if (!$mavenProductInfo->hasVersion($version)) {
         throw new HttpNotFoundException($request);
@@ -85,12 +86,10 @@ class ProductAction
         
         
         $mavenArtifacts = array_filter($mavenArtifacts, fn(MavenArtifact $a) => !$a->isProductArtifact());
-        $requestVersion = self::readIvyVersionCookie($request);
         $versionsToDisplay = $mavenProductInfo->getVersionsToDisplay($showDevVersions, $requestVersion);
         if (empty($initVersion) && !empty($versionsToDisplay)) {
           $version = $versionsToDisplay[0];
         }
-        
         $docArtifact = $mavenProductInfo->getFirstDocArtifact();
         if ($docArtifact != null) {
           $exists = (new ProductMavenArtifactDownloader())->downloadArtifact($product, $docArtifact, $version);

--- a/src/app/pages/market/product.twig
+++ b/src/app/pages/market/product.twig
@@ -158,16 +158,17 @@
           </select>
         </span>
       {% endif %}
-      {% if mavenProductInfo != null %}
+      {% if versionsToDisplay != null %}
        <span class="dropdown">
           <label>Choose target platform</label>
           <select name="version" id="version" onchange="updateDownloadArtifact(this);">
-          {% for version in mavenProductInfo.versionsToDisplay %}            
+          {% for version in versionsToDisplay %}            
             <a href="#">
-              <option value="{{ product.url }}/{{ version }}" {{ (version == selectedVersion) ? 'selected' : '' }}>Version {{ version|replace({'-SNAPSHOT':''}) }}</option>
+              <option value="{{ product.url }}/{{ version }}" {{ (version == selectedVersion) ? 'selected' : '' }}>Version {{ version }}</option>
             </a>
           {% endfor %}
           </select>
+          <a style="font-size:12px;position:absolute;left:5px;" href="{{ showDevVersionsLink }}">{{ switchVersion }}</a>
         </span>
       {% endif %}
 
@@ -181,13 +182,13 @@
 <section class="product-install">
   <div class="inner product-meta">
     <article class="alt p-grid p-justify-end p-align-center">
-      {% if mavenProductInfo != null %}
+      {% if versionsToDisplay != null %}
        <span class="dropdown">
           <label>Version</label>
           <select name="installVersion" id="installVersion" onchange="updateInstallArtifact(this);">
-          {% for version in mavenProductInfo.versionsToDisplay %}            
+          {% for version in versionsToDisplay %}            
             <a href="#">
-              <option value="{{ product.url }}/{{ version }}" data-meta-json-url="{{ installButton.getProductJsonUrl(version)|raw }}" {{ (version == selectedVersion) ? 'selected' : '' }}>Version {{ version|replace({'-SNAPSHOT':''}) }}</option>
+              <option value="{{ product.url }}/{{ version }}" data-meta-json-url="{{ installButton.getProductJsonUrl(version)|raw }}" {{ (version == selectedVersion) ? 'selected' : '' }}>Version {{ version }}</option>
             </a>
           {% endfor %}
           </select>

--- a/src/app/permalink/PortalPermalinkAction.php
+++ b/src/app/permalink/PortalPermalinkAction.php
@@ -70,7 +70,7 @@ class PortalPermalinkAction
     }
 
     if (self::isMinorVersion($version)) {
-      $portalVersions = $portal->getVersionsToDisplay();
+      $portalVersions = $portal->getVersionsToDisplay(true, null);
       foreach ($portalVersions as $v) {
         if (StringUtil::startsWith($v, $version)) {
           return $v;

--- a/src/app/permalink/PortalPermalinkAction.php
+++ b/src/app/permalink/PortalPermalinkAction.php
@@ -66,7 +66,7 @@ class PortalPermalinkAction
     }
 
     if ($version == 'latest') {
-      return $portal->getLatestVersionToDisplay();
+      return $portal->getLatestVersionToDisplay(true, null);
     }
 
     if (self::isMinorVersion($version)) {

--- a/test/pages/market/ProductActionTest.php
+++ b/test/pages/market/ProductActionTest.php
@@ -55,12 +55,30 @@ class ProductActionTest extends TestCase
       ->bodyContains("http://localhost/market-cache/doc-factory/doc-factory-product/$version/_product.json");
   }
   
+  public function testInstallButton_byDefaulNoSnapshotVersions()
+  {
+    $product = Market::getProductByKey('doc-factory');
+    // grab latest minor version of doc factory
+    $version = '';    
+    foreach ($product->getMavenProductInfo()->getVersionsToDisplay(false, '9.4.0') as $v)
+    {
+        if (StringUtil::startsWith($v, '9.4')) {
+           $version = $v;
+           break;
+        }
+    }
+    AppTester::assertThatGet('http://localhost/market/doc-factory')
+      ->ok()
+      ->bodyContains("http://localhost/market-cache/doc-factory/doc-factory-product/$version/_product.json")
+      ->bodyDoesNotContain("SNAPSHOT");
+  }
+
   public function testInstallButton_respectCookie_ltsMatchInstaller()
   {
     $product = Market::getProductByKey('doc-factory');
     // grab latest minor version of doc factory
     $version = '';    
-    foreach ($product->getMavenProductInfo()->getVersionsToDisplay() as $v)
+    foreach ($product->getMavenProductInfo()->getVersionsToDisplay(false, '9.4.0') as $v)
     {
         if (StringUtil::startsWith($v, '9.4')) {
            $version = $v;
@@ -79,12 +97,27 @@ class ProductActionTest extends TestCase
         ->bodyContains("http://localhost/_market/portal/_product.json?version=8.0.10");
   }
   
+  public function testInstallButton_respectCookie_bestMatchInstaller_showSnapshotIfNoMatch()
+  {
+      AppTester::assertThatGetWithCookie('http://localhost/market/doc-factory', ['ivy-version' => '9.4.1'])
+        ->ok()
+        ->bodyContains("http://localhost/market-cache/doc-factory/doc-factory-product/9.4.1-SNAPSHOT/_product.json");
+  }
+
+  public function testInstallButton_respectCookie_bestMatchInstaller_dontShowSnapshotIfNoNeeded()
+  {
+      AppTester::assertThatGetWithCookie('http://localhost/market/doc-factory', ['ivy-version' => '9.4.0'])
+        ->ok()
+        ->bodyContains("http://localhost/market-cache/doc-factory/doc-factory-product/9.4.0/_product.json")
+        ->bodyDoesNotContain("9.4.1-SNAPSHOT");
+  }
+
   public function testInstallButton_respectCookie_bestMatchInstaller_ifNotExistUseLast()
   {
     $product = Market::getProductByKey('portal');
     $version = '';
     // grab latest minor version of doc factory
-    foreach ($product->getMavenProductInfo()->getVersionsToDisplay() as $v)
+    foreach ($product->getMavenProductInfo()->getVersionsToDisplay(true, null) as $v)
     {
         if (StringUtil::startsWith($v, '8.0')) {
             $version = $v;
@@ -164,6 +197,26 @@ class ProductActionTest extends TestCase
       ->bodyDoesNotContain('-SNAPSHOT</option>');
   }
   
+  /**
+    * @runInSeparateProcess
+    */
+  public function testDontDisplaySnapshotInVersionDropdownWhenEnabled() 
+  {
+    AppTester::assertThatGet('market/doc-factory?showDevVersions=true')
+      ->ok()
+      ->bodyContains('-SNAPSHOT</option>');
+  }
+
+  /**
+    * @runInSeparateProcess
+    */
+  public function testDontDisplaySnapshotInVersionDropdownWhenHiding() 
+  {
+    AppTester::assertThatGet('market/doc-factory?showDevVersions=false')
+      ->ok()
+      ->bodyDoesNotContain('-SNAPSHOT</option>');
+  }
+
   public function testShowBuildStatusBadge() 
   {
     AppTester::assertThatGet('market/excel-connector')

--- a/test/pages/market/ProductActionTest.php
+++ b/test/pages/market/ProductActionTest.php
@@ -48,7 +48,7 @@ class ProductActionTest extends TestCase
   public function testInstallButton_byDefaultWithCurrentVersion()
   {
     $product = Market::getProductByKey('doc-factory');
-    $version = $product->getMavenProductInfo()->getLatestVersionToDisplay();
+    $version = $product->getMavenProductInfo()->getLatestVersionToDisplay(false, null);
 
     AppTester::assertThatGetWithCookie('http://localhost/market/doc-factory', ['ivy-version' => $version])
       ->ok()

--- a/test/permalink/PortalPermalinkActionTest.php
+++ b/test/permalink/PortalPermalinkActionTest.php
@@ -50,7 +50,7 @@ class PortalPermalinkActionTest extends TestCase
   private static function latestVersionOfMinorVersionPortal($minorVersion)
   {
     $portal = Market::getProductByKey('portal');
-    $portalVersions = $portal->getMavenProductInfo()->getVersionsToDisplay();
+    $portalVersions = $portal->getMavenProductInfo()->getVersionsToDisplay(true, null);
     foreach ($portalVersions as $v) {
       if (StringUtil::startsWith($v, $minorVersion)) {
         return $v;
@@ -78,7 +78,7 @@ class PortalPermalinkActionTest extends TestCase
 
   private function getLatestVersion($version)
   {
-    $portalVersions = Market::getProductByKey('portal')->getMavenProductInfo()->getVersionsToDisplay();
+    $portalVersions = Market::getProductByKey('portal')->getMavenProductInfo()->getVersionsToDisplay(true, null);
     foreach ($portalVersions as $v) {
       if (StringUtil::startsWith($v, $version)) {
         return $v;

--- a/test/permalink/PortalPermalinkActionTest.php
+++ b/test/permalink/PortalPermalinkActionTest.php
@@ -38,7 +38,7 @@ class PortalPermalinkActionTest extends TestCase
 
   public function testPortalLatest()
   {
-    AppTester::assertThatGet('/portal/latest')->redirect('/market/portal/' . Market::getProductByKey('portal')->getMavenProductInfo()->getLatestVersionToDisplay());
+    AppTester::assertThatGet('/portal/latest')->redirect('/market/portal/' . Market::getProductByKey('portal')->getMavenProductInfo()->getLatestVersionToDisplay(true, null));
   }
 
   public function testPortalDoc()


### PR DESCRIPTION
- Never cut "-SNASPHOT" off
- By default never show -SNAPSHOT versions
- Add link to show -SNAPSHOT version, keep state of this link as cookie
- By default show -SNAPSHOT version of matching Axon Ivy Designer if needed

![image](https://user-images.githubusercontent.com/7498380/194862033-5f98ad8e-af11-47fd-a9ed-55708a46cb73.png)

I can only merge this, as soon as we have released demo-projects properly.